### PR TITLE
Restore the Python 3.10 test floor and credit contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,10 @@ The `Publish Atlas website` workflow revalidates and regenerates `site/` before 
 
 The atlas covers interactive commands, nested subcommands, CLI flags, configuration, environment variables, shortcuts, hooks, permissions, MCP, skills, and agent controls across all six ecosystems. It stays a living reference rather than a claim that fast-moving vendor surfaces can ever be permanently complete. See [the roadmap](docs/ROADMAP.md).
 
+## Acknowledgements
+
+Thanks to the people who have improved the atlas beyond its data:
+
+- [@WhiteHades](https://github.com/WhiteHades) — case-sensitive CLI flag ranking, accessible skip links and mobile navigation, route collision checks, HTTPS redirect enforcement, and validation that reports malformed records instead of raising.
+
 Released under the [MIT License](LICENSE).

--- a/tests/test_check_sources.py
+++ b/tests/test_check_sources.py
@@ -13,9 +13,15 @@ class SourceCheckerTests(unittest.TestCase):
     def setUp(self):
         self.responses = {}
         self.requests = []
-        self.enterContext(patch.object(urllib.request, "_opener", None))
+        # TestCase.enterContext is 3.11+; start/addCleanup keeps the suite runnable on 3.10.
+        self.start_patch(patch.object(urllib.request, "_opener", None))
         for handler, method in ((urllib.request.HTTPSHandler, "https_open"), (urllib.request.HTTPHandler, "http_open")):
-            self.enterContext(patch.object(handler, method, side_effect=self.respond))
+            self.start_patch(patch.object(handler, method, side_effect=self.respond))
+
+    def start_patch(self, patcher):
+        value = patcher.start()
+        self.addCleanup(patcher.stop)
+        return value
 
     def respond(self, request):
         self.requests.append(request.full_url)


### PR DESCRIPTION
Two follow-ups to #1, which is now merged.

**Keep the source-checker tests runnable on Python 3.10.** `TestCase.enterContext` landed in 3.11, so the nine new source-checker tests errored out with `AttributeError` on 3.10. CI pins 3.12 and stayed green, which hid the raised floor. Swapped in `start()`/`addCleanup`, which behaves identically and works everywhere.

**Credit contributors in the README.** New acknowledgements section naming @WhiteHades for the search, accessibility, route, source, and validation fixes in #1, so the credit is durable in the repo rather than only in commit metadata.

Verified on both interpreters:

| Check | Result |
| --- | --- |
| `scripts/validate.py` | OK — 2604 entries, 33 capabilities |
| `python -m unittest discover -s tests` (3.10) | 37 passed |
| `python -m unittest discover -s tests` (3.12) | 37 passed |
| `node tests/test_site_search.js` | valid |
| working tree after rebuild | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rw2KxMtReyjCJDwrgVtZR